### PR TITLE
Support for debug mode and for mpq.register

### DIFF
--- a/Controller/Component/MixpanelComponent.php
+++ b/Controller/Component/MixpanelComponent.php
@@ -16,8 +16,10 @@ class MixpanelComponent extends Component {
 	
 	function beforeRender() {
 		Configure::write('Mixpanel.events', $this->Session->read('Mixpanel.events'));
+		Configure::write('Mixpanel.register', $this->Session->read('Mixpanel.register'));
 		Configure::write('Mixpanel.settings', $this->settings);
 		$this->Session->delete('Mixpanel.events');
+		$this->Session->delete('Mixpanel.register');
 	}
 	
 	function name_tag($name) {
@@ -26,6 +28,22 @@ class MixpanelComponent extends Component {
 	
 	function identify($id) {
 		$this->settings['identify'] = $id;
+	}
+
+/**
+ * Register new properties using mpq.register(), accepts a key => value array of properties
+ * Sending a key => value with a duplicate key replaces the old value
+ *
+ * @param array $properties Array of key => value properties to register
+ * @return void
+ * @author David Kullmann
+ */
+	function register($properties) {
+		$register = $this->Session->read('Mixpanel.register');
+		foreach($properties as $key => $value) {
+			$register[$key] = $value;
+		}
+		$this->Session->write('Mixpanel.register', $register);
 	}
 	
 	function track($event, $properties = array()) {

--- a/View/Helper/MixpanelHelper.php
+++ b/View/Helper/MixpanelHelper.php
@@ -14,10 +14,12 @@ class MixpanelHelper extends AppHelper {
 TRACKERS
 </script><!-- end Mixpanel -->
 HTML;
+
 		$settings = Configure::read('Mixpanel.settings');
 		$events = Configure::read('Mixpanel.events');
 		
 		$trackers = array();
+		if (Configure::read('debug')) $trackers[] = 'mpq.set_config({debug: true});';
 		if (isset($settings['identify'])) $trackers[] = sprintf('mpq.identify(%s);', json_encode($settings['identify']));
 		if (isset($settings['name_tag'])) $trackers[] = sprintf('mpq.name_tag(%s);', json_encode($settings['name_tag']));
 		

--- a/View/Helper/MixpanelHelper.php
+++ b/View/Helper/MixpanelHelper.php
@@ -16,12 +16,14 @@ TRACKERS
 HTML;
 
 		$settings = Configure::read('Mixpanel.settings');
-		$events = Configure::read('Mixpanel.events');
+		$events   = Configure::read('Mixpanel.events');
+		$register = Configure::read('Mixpanel.register');
 		
 		$trackers = array();
 		if (Configure::read('debug')) $trackers[] = 'mpq.set_config({debug: true});';
 		if (isset($settings['identify'])) $trackers[] = sprintf('mpq.identify(%s);', json_encode($settings['identify']));
 		if (isset($settings['name_tag'])) $trackers[] = sprintf('mpq.name_tag(%s);', json_encode($settings['name_tag']));
+		if (isset($register)) $trackers[] = sprintf('mpq.registry(%s);', json_encode($register));
 		
 		foreach ($events as $event) {
 			$properties = $event['properties'];

--- a/View/Helper/MixpanelHelper.php
+++ b/View/Helper/MixpanelHelper.php
@@ -23,7 +23,7 @@ HTML;
 		if (Configure::read('debug')) $trackers[] = 'mpq.set_config({debug: true});';
 		if (isset($settings['identify'])) $trackers[] = sprintf('mpq.identify(%s);', json_encode($settings['identify']));
 		if (isset($settings['name_tag'])) $trackers[] = sprintf('mpq.name_tag(%s);', json_encode($settings['name_tag']));
-		if (isset($register)) $trackers[] = sprintf('mpq.registry(%s);', json_encode($register));
+		if (isset($register)) $trackers[] = sprintf('mpq.register(%s);', json_encode($register));
 		
 		foreach ($events as $event) {
 			$properties = $event['properties'];

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Then add to your app:
         // if a user is logged in
         $this->Mixpanel->identify($user_id);
         $this->Mixpanel->name_tag($user_name);
+        $this->Mixpanel->register($superProperties);
     }
 
     /* app/Controller/PostController.php */


### PR DESCRIPTION
1. Added support for mpq.set_config({debug: true}) if you are in CakePHP debug mode
2. Added support for mpq.register via MixpanelComponent::register() method.

-DK
